### PR TITLE
handle missing auth from config

### DIFF
--- a/op.yml
+++ b/op.yml
@@ -52,4 +52,4 @@ run:
         - sh
         - -ce
         - |
-          cat /input | jq '{auths: .auths}' > /output
+          cat /input | jq 'if .auths != null then {auths: .auths} else {auths: {}} end' > /output


### PR DESCRIPTION
Docker Desktop version 4.10.1+ no longer guarantee's the "auth" property will exist in the ~/docker/config.json file. This change handles if that property does not exist. 